### PR TITLE
docs: Change HackerOne link to GitHub

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,7 @@ Security updates are applied only to the most recent releases.
 
 ## Reporting a Vulnerability
 
-To securely report a vulnerability, please visit https://hackerone.com/eslint.
-
-Please **do not** file a GitHub issue for a vulnerability.
+To securely report a vulnerability, please [open an advisory on GitHub](https://github.com/eslint/eslint/security/advisories/new). This form is also accessible when [submitting a new issue](https://github.com/eslint/eslint/issues/new/choose).
 
 ## Vulnerability Process
 


### PR DESCRIPTION
After the most recent TSC meeting, we're migrating from HackerOne to GitHub's vulnerability disclosure program.