### PR TITLE
docs: create `PULL_REQUEST_TEMPLATE.md`

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+    Thank you for contributing!
+
+    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
+-->
+
+#### Prerequisites checklist
+
+- [ ] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).
+
+<!--
+    Please ensure your pull request is ready:
+
+    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
+    - Update or create tests
+    - If performance-related, include a benchmark
+    - Update documentation for this change (if appropriate)
+-->
+
+<!--
+    The following is required for all pull requests:
+-->
+
+#### What is the purpose of this pull request?
+
+#### What changes did you make? (Give an overview)
+
+#### Related Issues
+
+<!-- include tags like "fixes #123" or "refs #123" -->
+
+#### Is there anything you'd like reviewers to focus on?


### PR DESCRIPTION
Hello,

In this PR, I’ve added a default `PULL_REQUEST_TEMPLATE.md`.

While reviewing other ESLint repositories, I noticed a few that don’t have their own `PULL_REQUEST_TEMPLATE.md`.

According to the [GitHub guide](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types), a `PULL_REQUEST_TEMPLATE` can also be managed centrally in the `.github` repository.

![image](https://github.com/user-attachments/assets/36caefb9-2160-45b6-b6e6-c85d250b8a76)
