### PR TITLE
docs: add default issue template to require AI acknowledgment

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: "\U0001F41E Report a problem"
-description: "Report a problem with ESLint"
+description: "Report a problem with this project"
 title: "Bug: (fill in)"
 labels:
     - bug

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,65 @@
+name: "\U0001F41E Report a problem"
+description: "Report a problem with ESLint"
+title: "Bug: (fill in)"
+labels:
+    - bug
+    - "repro:needed"
+body:
+    - type: markdown
+      attributes:
+          value: By opening an issue, you agree to abide by the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
+    - type: textarea
+      attributes:
+          label: Environment
+          description: |
+              Please provide the following information:
+          value: |
+              Node version:
+              npm version:
+              ESLint version:
+              Operating System:
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: What did you do?
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: What did you expect to happen?
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: What actually happened?
+      validations:
+          required: true
+    - type: input
+      attributes:
+          label: Link to Minimal Reproducible Example
+          description: "Link to a [StackBlitz](https://stackblitz.com) or GitHub repo with a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed."
+          placeholder: "https://stackblitz.com/abcd1234"
+      validations:
+          required: true
+    - type: checkboxes
+      attributes:
+          label: Participation
+          options:
+              - label: I am willing to submit a pull request for this issue.
+                required: false
+    - type: markdown
+      attributes:
+          value: Please **do not** open a pull request until this issue has been accepted by the team.
+    - type: checkboxes
+      attributes:
+          label: AI acknowledgment
+          options:
+              - label: I did not use AI to generate this issue report.
+                required: false
+              - label: (If the above is not checked) I have reviewed the AI-generated content before submitting.
+                required: false
+    - type: textarea
+      attributes:
+          label: Additional comments
+          description: Is there anything else you'd like to mention?

--- a/.github/ISSUE_TEMPLATE/change.yml
+++ b/.github/ISSUE_TEMPLATE/change.yml
@@ -1,0 +1,44 @@
+name: "\U0001F680 Request a change"
+description: "Request a new feature or change to an existing feature"
+title: "Change Request: (fill in)"
+labels:
+    - enhancement
+body:
+    - type: markdown
+      attributes:
+          value: By opening an issue, you agree to abide by the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
+    - type: textarea
+      attributes:
+          label: What problem do you want to solve?
+          description: |
+              Please explain your use case in as much detail as possible without referring to a specific solution.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: What do you think is the correct solution?
+          description: |
+              Please explain what you'd like to change to address the problem.
+      validations:
+          required: true
+    - type: checkboxes
+      attributes:
+          label: Participation
+          options:
+              - label: I am willing to submit a pull request for this change.
+                required: false
+    - type: markdown
+      attributes:
+          value: Please **do not** open a pull request until this issue has been accepted by the team.
+    - type: checkboxes
+      attributes:
+          label: AI acknowledgment
+          options:
+              - label: I did not use AI to generate this issue report.
+                required: false
+              - label: (If the above is not checked) I have reviewed the AI-generated content before submitting.
+                required: false
+    - type: textarea
+      attributes:
+          label: Additional comments
+          description: Is there anything else you'd like to mention?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Discord Server
+      url: https://eslint.org/chat
+      about: Talk with the team

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,44 @@
+name: "\U0001F4DD Documentation Change"
+description: "Request an improvement to documentation"
+title: "Docs: (fill in)"
+labels:
+    - documentation
+body:
+    - type: markdown
+      attributes:
+          value: By opening an issue, you agree to abide by the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
+    - type: textarea
+      attributes:
+          label: What documentation issue do you want to solve?
+          description: |
+              Please explain your issue in as much detail as possible.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: What do you think is the correct solution?
+          description: |
+              Please explain how you'd like to change the documentation for this project to address the problem.
+      validations:
+          required: true
+    - type: checkboxes
+      attributes:
+          label: Participation
+          options:
+              - label: I am willing to submit a pull request for this change.
+                required: false
+    - type: markdown
+      attributes:
+          value: Please **do not** open a pull request until this issue has been accepted by the team.
+    - type: checkboxes
+      attributes:
+          label: AI acknowledgment
+          options:
+              - label: I did not use AI to generate this issue report.
+                required: false
+              - label: (If the above is not checked) I have reviewed the AI-generated content before submitting.
+                required: false
+    - type: textarea
+      attributes:
+          label: Additional comments
+          description: Is there anything else you'd like to mention?

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# Editor Configuration Files
+.vscode/
+*.code-workspace
+
 # Automatically generated files by GitHub Actions workflow
 /.shared-workflows


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR adds default issue templates that require AI acknowledgment.

The PR for the AI usage policy (https://github.com/eslint/eslint/pull/20510) has been merged, and it now requires disclosure of AI usage. However, some repositories like `eslint-github-bot`, `eslintrc`, and others don't yet have issue templates.

This is a problem because users can only open an empty issue template and there are no AI acknowledgment checkboxes by default.

I followed the template used by `js` (https://github.com/eslint/js/tree/main/.github/ISSUE_TEMPLATE) and tweaked it slightly to serve as a general default template.

Other opinions or feedback on the default template are welcome.

## What changes did you make? (Give an overview)

This PR adds default issue templates that require AI acknowledgment.

## Related Issues

Ref: https://github.com/eslint/eslint/pull/20510

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

The issue templates under `.github/ISSUE_TEMPLATE` apply to all ESLint repositories. They are overridden by any existing templates, so repositories that already have their own issue templates won't be affected.
