### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -12,7 +12,6 @@ on:
             - opened
             - reopened
 
-
 permissions:
   contents: read
 

--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -12,6 +12,10 @@ on:
             - opened
             - reopened
 
+
+permissions:
+  contents: read
+
 jobs:
     add-to-triage:
         uses: eslint/workflows/.github/workflows/add-to-triage.yml@main

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,7 +6,6 @@ on:
 
     workflow_dispatch:
 
-
 permissions:
   contents: read
 

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,6 +6,10 @@ on:
 
     workflow_dispatch:
 
+
+permissions:
+  contents: read
+
 jobs:
     update-readme:
         uses: eslint/workflows/.github/workflows/update-readme.yml@main


### PR DESCRIPTION
Hardens 2 workflow(s) in this repo by declaring a workflow-level `permissions: contents: read`. Today those workflows inherit the legacy broad read-write GITHUB_TOKEN; the read-only default reduces blast radius if any step is compromised.

I checked each file - they read the checkout and run tests/lints; no GitHub API writes (no `gh pr/issue`, no `git push`, no release/publish/comment actions). So behavior is unchanged.

Reference: the tj-actions/changed-files compromise (CVE-2025-30066) is the canonical reason to apply least-privilege defaults.